### PR TITLE
fix: add babel-runtime as dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "@gem-mine/durex": "^2.0.6",
+    "babel-runtime": "^6.26.0",
     "connected-react-router": "^6.5.2",
     "path-to-regexp": "^3.0.0",
     "query-string": "^5.1.1",


### PR DESCRIPTION
添加缺少的运行时依赖 babel-runtime